### PR TITLE
Make Component Types callable

### DIFF
--- a/padloper/structure.py
+++ b/padloper/structure.py
@@ -752,6 +752,8 @@ class ComponentType(Vertex):
     def __repr__(self):
         return f"{self.category}: {self.name} ({self._id})"
 
+    def __call__(self, name):
+        return Component(name, self)
 
 class ComponentVersion(Vertex):
     """
@@ -1516,6 +1518,7 @@ class Component(Vertex):
             result.append((subcomponent))
 
         return result
+    subs = property(get_all_subcomponents)
 
     def get_all_supercomponents(self):
         """Return all supercomponents connected to this component of the form
@@ -2251,7 +2254,7 @@ class Component(Vertex):
             )
 
             current_subcomponent.add()
-            print(f'subcomponent connected: {self} -> {other}')
+            print(f'subcomponent connected: {self} -> {component}')
 
 
     def get_subcomponent(self, component):


### PR DESCRIPTION
One typo fix, two suggestions.

1.  added `subs` property of a component so you can, instead of eg `switch1.get_all_subcomponents()` write 

```
In [5]: switch1.subs
Out[5]: 
[component ethernet-port: switch-wiz6-snABC_p04 (4192),
 component ethernet-port: switch-wiz6-snABC_p00 (8360),
 component ethernet-port: switch-wiz6-snABC_p02 (16552),
 component ethernet-port: switch-wiz6-snABC_p01 (40972360),
 component ethernet-port: switch-wiz6-snABC_p05 (40980488),
 component ethernet-port: switch-wiz6-snABC_p03 (81936464)]
```

2. Made `ComponentType` instances callable (by adding `__call__` fn to the class definition).  This allows:

```
In [2]: t_switch           = ComponentType("switch", "a network switch").add()
ComponentType with name switch already exists in the database.

In [4]: switch1  = t_switch("switch-wiz-snABC").add()
Component with name switch-wiz-snABC already exists in the database.

```

instead of 
```
In [3]: switch1  = Component("switch-wiz-snABC", t_switch).add()
Component with name switch-wiz-snABC already exists in the database.

```